### PR TITLE
avoid adding the column to the table if a DbBinder annotation doesn't…

### DIFF
--- a/app/src/main/java/com/tipz/helpers/control/database/DbEntityHelper.java
+++ b/app/src/main/java/com/tipz/helpers/control/database/DbEntityHelper.java
@@ -51,7 +51,7 @@ public abstract class DbEntityHelper extends SQLiteOpenHelper {
 
             // Run on the fields
             for (Field currField : currContract.getClass().getFields()) {
-                if (currField.getDeclaredAnnotations().length > 0) {
+                if (currField.getDeclaredAnnotations().length > 0 && currField.isAnnotationPresent(DbBinder.class)) {
 
                     DbBinder annotation = currField.getAnnotation(DbBinder.class);
 


### PR DESCRIPTION
We fixed a bug in the db helper - unwanted columns were added when they had an annotation such as JsonIgnore. Added a check that a DBBinder annotation exists.
